### PR TITLE
[Hotfix] 마인더 전환 시 websocket 오류 수정

### DIFF
--- a/src/contexts/StompContext.tsx
+++ b/src/contexts/StompContext.tsx
@@ -98,9 +98,10 @@ export const StompProvider: React.FC<{ children: ReactNode }> = ({
       },
       (error: any) => {
         setIsConnected(false);
-        console.error(error);
         if (error.headers.message === 'UNAUTHORIZED') {
           reissueToken();
+        } else if (error.headers.message === '404 NOT_FOUND') {
+          console.error(error.command, error.headers.message);
         } else {
           alert(error);
         }


### PR DESCRIPTION
## Checklist

<br>

- [X] 올바른 브랜치에 PR을 보내도록 설정하였나요?
- [X] PR의 라벨을 올바르게 달았나요?

<br>

## Description

<br>
마인더 전환 시 websocket 오류 수정하였습니다. stomp provider에 조건문 하나 추가했으니 가볍게 보면 될 거 같습니다~
<br>

## Related Issues

<br>
#161 
<br>

