### PR TITLE
[Hotfix] 공개상담 댓글 썻을 경우 버튼 비활성화 + 추가적으로 자잘한 것 2가지 구현

### DIFF
--- a/src/api/get.ts
+++ b/src/api/get.ts
@@ -149,6 +149,9 @@ export const getCounselorsComments = async (postId: any) =>
 export const getCustomersComments = async (postId: any) =>
   await getInstance(`/comments/customers/${postId}`);
 
+export const getCounselorsIsWriteComments = async (postId: any) =>
+  await getInstance(`/comments/counselors/authentication/${postId}`);
+
 // Post Controller
 export const getOneOpenConsult = async (id: string | undefined) =>
   await getInstance(`/posts/${id}`);

--- a/src/components/Buyer/BuyerConsult/BuyerOpenConsultSection.tsx
+++ b/src/components/Buyer/BuyerConsult/BuyerOpenConsultSection.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { Green, Grey1, Grey2, Grey3, Grey6 } from 'styles/color';
 import { Body1, Body3, Caption1, Heading } from 'styles/font';
 import { LoadingSpinner } from 'utils/LoadingSpinner';
-import { isBuyPopupOpenState, isConsultModalOpenState } from 'utils/atom';
+import { isBuyPopupOpenState } from 'utils/atom';
 import { ReactComponent as LockIcon } from 'assets/icons/icon-lock.svg';
 import { ReactComponent as HeartIcon } from 'assets/icons/icon-heart2.svg';
 import { ReactComponent as SaveIcon } from 'assets/icons/icon-save2.svg';
@@ -279,14 +279,6 @@ const TimeLeft = styled.div`
   right: 1.6rem;
 `;
 
-const CreateConsultButton = styled.button`
-  width: 5.8rem;
-  height: 5.8rem;
-  border-radius: 100%;
-  background-color: ${Green};
-  box-shadow: 0px 0px 12px 0px rgba(0, 0, 0, 0.25);
-  align-self: flex-end;
-`;
 const CreateConsultButtonWrapper = styled.div`
   width: 100%;
   padding: 0 2rem;

--- a/src/components/Common/Profile.tsx
+++ b/src/components/Common/Profile.tsx
@@ -11,7 +11,7 @@ import { Characters } from 'utils/Characters';
 interface ProfileProps {
   isBuyer: boolean;
   isVerified?: undefined | boolean;
-  profileIdentifier: number | undefined;
+  profileIdentifier: number | null | undefined;
   name: string | undefined;
   levelStatus: string | undefined;
   isPass?: boolean | undefined;
@@ -29,7 +29,8 @@ export const Profile = ({
   return (
     <>
       <ProfileBox>
-        <Characters number={profileIdentifier} width="7.6rem" />
+        {/* 프로플 만들지 않았을 때, 기본 프로필을 4번으로 */}
+        <Characters number={profileIdentifier ?? 4} width="7.6rem" />
 
         {isBuyer ? (
           <Name>{name}</Name>

--- a/src/components/Seller/Common/BankSelectModal.tsx
+++ b/src/components/Seller/Common/BankSelectModal.tsx
@@ -1,4 +1,4 @@
-import React, { SetStateAction } from 'react';
+import React from 'react';
 import { useRecoilState } from 'recoil';
 import styled, { keyframes } from 'styled-components';
 import { Grey4, Grey6 } from 'styles/color';
@@ -7,7 +7,7 @@ import { BankIcon } from 'utils/BankIcon';
 import { isBankModalOpenState } from 'utils/atom';
 import { bankNameList } from 'utils/constant';
 interface BankSelectModalProps {
-  setSelectBankType: React.Dispatch<SetStateAction<string>>;
+  setSelectBankType: React.Dispatch<React.SetStateAction<string | null>>;
 }
 function BankSelectModal({ setSelectBankType }: BankSelectModalProps) {
   const [isBankModalOpen, setIsBankModalOpen] =

--- a/src/components/Seller/SellerOpenConsult/BottomSection.tsx
+++ b/src/components/Seller/SellerOpenConsult/BottomSection.tsx
@@ -1,5 +1,5 @@
 import { Button } from 'components/Common/Button';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import reactTextareaAutosize from 'react-textarea-autosize';
 import styled from 'styled-components';
 import { ReactComponent as SendIcon } from 'assets/icons/icon-send.svg';
@@ -7,6 +7,7 @@ import { Green, Grey3, Grey6, LightGreen, White } from 'styles/color';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { isSendPopupOpenState } from 'utils/atom';
 import { useNavigate, useParams } from 'react-router-dom';
+import { getCounselorsIsWriteComments } from 'api/get';
 interface BottomSectionProps {
   isReplying: boolean;
   setIsReplying: React.Dispatch<React.SetStateAction<boolean>>;
@@ -22,6 +23,7 @@ function BottomSection({
   const navigate = useNavigate();
   const setIsSendPopupOpen = useSetRecoilState(isSendPopupOpenState);
   const { consultid } = useParams();
+  const [isAlreadyWrite, setIsAlreadyWrite] = useState<boolean>(false);
   const handleNavigateRandomConsult = () => {
     if (localStorage.getItem('randomConsult')) {
       const randomNumList = JSON.parse(localStorage.getItem('randomConsult'));
@@ -34,6 +36,18 @@ function BottomSection({
     }
     // 그냥 open-consult id쳐서 들어왔을 경우 추후 예외처리..
   };
+  useEffect(() => {
+    const fetchIsAlreadyWrite = async () => {
+      const res: any = await getCounselorsIsWriteComments(consultid);
+      if (res.status === 200) {
+        setIsAlreadyWrite(res.data);
+      } else if (res.response.status === 404) {
+        alert('존재하지 않는 상담입니다.');
+        navigate('/minder/consult?type=open-consult');
+      }
+    };
+    fetchIsAlreadyWrite();
+  });
   return (
     <BottomSectionWrapper>
       {isReplying ? (
@@ -70,10 +84,13 @@ function BottomSection({
           <Button
             text={'답장쓰기'}
             width="100%"
+            isActive={!isAlreadyWrite}
             backgroundColor={Green}
             height="5.2rem"
             onClick={() => {
-              setIsReplying(true);
+              if (!isAlreadyWrite) {
+                setIsReplying(true);
+              }
             }}
           />
         </div>

--- a/src/components/Seller/SellerOpenConsult/BottomSection.tsx
+++ b/src/components/Seller/SellerOpenConsult/BottomSection.tsx
@@ -4,7 +4,7 @@ import reactTextareaAutosize from 'react-textarea-autosize';
 import styled from 'styled-components';
 import { ReactComponent as SendIcon } from 'assets/icons/icon-send.svg';
 import { Green, Grey3, Grey6, LightGreen, White } from 'styles/color';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 import { isSendPopupOpenState } from 'utils/atom';
 import { useNavigate, useParams } from 'react-router-dom';
 import { getCounselorsIsWriteComments } from 'api/get';
@@ -22,11 +22,12 @@ function BottomSection({
 }: BottomSectionProps) {
   const navigate = useNavigate();
   const setIsSendPopupOpen = useSetRecoilState(isSendPopupOpenState);
-  const { consultid } = useParams();
+  const { consultid } = useParams() as { consultid: string };
   const [isAlreadyWrite, setIsAlreadyWrite] = useState<boolean>(false);
   const handleNavigateRandomConsult = () => {
-    if (localStorage.getItem('randomConsult')) {
-      const randomNumList = JSON.parse(localStorage.getItem('randomConsult'));
+    const randomNumListString = localStorage.getItem('randomConsult');
+    if (randomNumListString != null) {
+      const randomNumList = JSON.parse(randomNumListString);
       const navigateId =
         randomNumList[
           (randomNumList.indexOf(parseInt(consultid)) + 1) %

--- a/src/pages/Buyer/BuyerPayment.tsx
+++ b/src/pages/Buyer/BuyerPayment.tsx
@@ -2,12 +2,13 @@ import { getPaymentsCustomers } from 'api/get';
 import { PaymentCard } from 'components/Buyer/BuyerPayment/PaymentCard';
 import { PaymentModal } from 'components/Buyer/BuyerPayment/PaymentModal';
 import { BackIcon, HeaderWrapper } from 'components/Buyer/Common/Header';
+import { Space } from 'components/Common/Space';
 import useIntersectionObserver from 'hooks/useIntersectionObserver';
 import { useLayoutEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilState, useSetRecoilState } from 'recoil';
 import styled from 'styled-components';
-import { Green, Grey1, Grey5, White } from 'styles/color';
+import { Green, Grey1, Grey5, Grey6, White } from 'styles/color';
 import { Button2, Heading } from 'styles/font';
 import { isPaymentModalOpenState, scrollLockState } from 'utils/atom';
 import { PaymentInfo } from 'utils/type';
@@ -190,6 +191,7 @@ export const BuyerPayment = () => {
             );
           })}
         </CardWrapper>
+        <Space height="4rem" />
         {!isLastElem ? (
           <div
             ref={setTarget}
@@ -232,12 +234,18 @@ const CardWrapper = styled.div`
   flex-direction: column;
   align-items: center;
   gap: 0.8rem;
+  height: calc(100% - 11.6rem);
+  overflow: scroll;
   margin-top: 1.2rem;
 `;
 const ToggleWrapper = styled.div`
   display: flex;
-  margin: 0.8rem 2rem;
+  padding: 0.8rem 2rem;
   gap: 0.8rem;
+  background-color: white;
+  border-bottom: 1px solid ${Grey6};
+  position: sticky;
+  top: 5.3rem;
 `;
 const ToggleButton = styled.div<{ focus: boolean }>`
   width: 8.1rem;

--- a/src/pages/Seller/SellerMypage.tsx
+++ b/src/pages/Seller/SellerMypage.tsx
@@ -12,7 +12,7 @@ interface UserInfo {
   nickname: string;
   level: string;
   isEducated: boolean;
-  consultStlyle: string;
+  consultStyle: string;
   profilesStatus: string;
 }
 export const SellerMypage = () => {

--- a/src/pages/Seller/SellerRefundBankAccount.tsx
+++ b/src/pages/Seller/SellerRefundBankAccount.tsx
@@ -11,15 +11,15 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
-import { Grey1, Grey3, Grey6 } from 'styles/color';
-import { Body1, Body3, Heading } from 'styles/font';
+import { Grey1, Grey6 } from 'styles/color';
+import { Body1, Heading } from 'styles/font';
 import { BankIcon } from 'utils/BankIcon';
 import { isBankModalOpenState } from 'utils/atom';
 
 function SellerRefundBankAccount() {
   const navigate = useNavigate();
-  const [accountNum, setAccountNum] = useState('');
-  const [bankType, setBankType] = useState(null);
+  const [accountNum, setAccountNum] = useState<string>('');
+  const [bankType, setBankType] = useState<string | null>(null);
   const [owner, setOwner] = useState('');
   // 은행 모달
   const [isBankModalOpen, setIsBankModalOpen] =
@@ -27,14 +27,9 @@ function SellerRefundBankAccount() {
 
   const [isActiveFisnishButton, setIsActiveFinishButton] = useState(false);
   useEffect(() => {
-    // API 요청
-    // setAccountNum('12345678900');
-    // setBankType('우리은행');
-    // setOwner('김고민');
-    // const res= getCounselorsAccount()
     const fetchAccountData = async () => {
       try {
-        const res:any = await getCounselorsAccount();
+        const res: any = await getCounselorsAccount();
         if (res.status === 200) {
           setAccountNum(res.data.account);
           setBankType(res.data.bank);


### PR DESCRIPTION
## Checklist

<br>

- [x] 올바른 브랜치에 PR을 보내도록 설정하였나요?
- [x] PR의 라벨을 올바르게 달았나요?

<br>

## Description

<br>

- 공개상담에서 상담사가 댓글 작성했을 여부를 얻어내는 api연동하여 댓글 작성하기 버튼을 댓글 작성 여부에 따라 비활성화하고 클릭이벤트를 막았습니다.
- 정보가 없는 상담사의 consultStyle이 null이어서  Char num이 매핑이 안돼서 view가 깨져서, 기본으로 들어가는 캐릭터를 4번으로 임의로 설정하였습니다.
- 상담사 결제내역 페이지에서 헤더 고정했습니다.
<br>

## Related Issues

<br>
관련된 이슈 number를 작성해주세요.
<br>

## To Reveiwer

<br>
가볍게 봐주세여
<br>
