### PR TITLE
[Hotfix] 최근 검색어 클릭 시 쿼리 파라미터로써 keyword 추가, 인증되지 않은 경우 공개상담 탭 접근 막고 alert 띄우기

### DIFF
--- a/src/components/Buyer/BuyerSearch/SearchRecent.tsx
+++ b/src/components/Buyer/BuyerSearch/SearchRecent.tsx
@@ -6,13 +6,10 @@ import { Grey1, Grey4 } from 'styles/color';
 import { ReactComponent as XIcon } from 'assets/icons/icon-grey-x.svg';
 import { getSearchWords } from 'api/get';
 import { deleteSearchWords } from 'api/delete';
-import { useSetRecoilState } from 'recoil';
-import { searchKeywordState } from 'utils/atom';
 import { useNavigate } from 'react-router-dom';
 export const SearchRecent = () => {
   const navigate = useNavigate();
   const [recentSearch, setRecentSearch] = useState<string[]>([]);
-  const setKeyword = useSetRecoilState(searchKeywordState);
   const handleXonClick = async (
     targetIndex: number,
     event: React.MouseEvent,
@@ -28,8 +25,7 @@ export const SearchRecent = () => {
     }
   };
   const handleRecentClick = (index: number) => {
-    setKeyword(recentSearch[index]);
-    navigate('/search/result');
+    navigate(`/search/result?keyword=${recentSearch[index]}`);
   };
   useEffect(() => {
     const fetchData = async () => {

--- a/src/components/Common/Header.tsx
+++ b/src/components/Common/Header.tsx
@@ -57,7 +57,7 @@ const Logo = styled.div`
   cursor: pointer;
 `;
 const StyledSearch = styled(Search)`
-  margin-top: 1rem;
+  margin-top: 1.4rem;
   margin-right: 2.4rem;
   cursor: pointer;
 `;

--- a/src/components/Common/Profile.tsx
+++ b/src/components/Common/Profile.tsx
@@ -101,6 +101,10 @@ export const Profile = ({
             onClick={() => {
               if (isPass) {
                 navigate('/minder/education/first');
+              } else {
+                alert(
+                  '마지막 인증 시험을 본 시간에서 24시간 이후에 시험을 응시할 수 있어요.',
+                );
               }
             }}
             width="100%"

--- a/src/components/Common/TabA1.tsx
+++ b/src/components/Common/TabA1.tsx
@@ -21,6 +21,9 @@ export const TabA1 = ({ isBuyer, initState }: TabA1Props) => {
       if (res.status === 200) {
         localStorage.setItem('randomConsult', JSON.stringify(res.data));
         navigate(`/minder/open-consult/${res.data[0]}`);
+        setTabState(3);
+      } else if (res?.response.status === 403) {
+        alert('공개 상담 페이지에 접근할 권한이 없습니다.');
       }
     } catch (err) {
       alert(err);
@@ -79,7 +82,6 @@ export const TabA1 = ({ isBuyer, initState }: TabA1Props) => {
       <TabButton
         $tabState={3}
         onClick={() => {
-          setTabState(3);
           if (isBuyer) {
             navigate('/open-consult');
           } else {

--- a/src/components/Seller/SellerHome/ConsultReviewsSection.tsx
+++ b/src/components/Seller/SellerHome/ConsultReviewsSection.tsx
@@ -29,7 +29,7 @@ export const ConsultReviewSection = () => {
     <>
       <ContentTag
         onClick={() => {
-          navigate('/minder/mypage/review');
+          navigate('/minder/mypage/review?from=home');
         }}
       >
         {reviewData?.length === 0 ? (

--- a/src/components/Seller/SellerMyPageReview/SellerReviewHeader.tsx
+++ b/src/components/Seller/SellerMyPageReview/SellerReviewHeader.tsx
@@ -1,19 +1,25 @@
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { White } from 'styles/color';
 import { ReactComponent as LeftArrowIcon } from 'assets/icons/left-arrow.svg';
 import { Heading } from 'styles/font';
+import { useCallback, useMemo } from 'react';
 
 export const SellerReviewHeader = () => {
+  const url = new URL(window.location.href);
+  const params = useMemo(() => new URLSearchParams(url.search), [url.search]);
   const navigate = useNavigate();
+  const handleClickBackIcon = useCallback(() => {
+    if (params.has('from', 'home')) {
+      navigate('/minder');
+    } else {
+      navigate('/minder/mypage');
+    }
+  }, [navigate, params]);
   return (
     <SellerReviewHeaderWrapper>
       <div style={{ position: 'absolute', left: '2rem', cursor: 'pointer' }}>
-        <LeftArrowIcon
-          onClick={() => {
-            navigate('/minder/mypage');
-          }}
-        />
+        <LeftArrowIcon onClick={handleClickBackIcon} />
       </div>
       <Heading>받은 리뷰</Heading>
     </SellerReviewHeaderWrapper>

--- a/src/pages/Seller/SellerMyPageModifyProfile.tsx
+++ b/src/pages/Seller/SellerMyPageModifyProfile.tsx
@@ -97,7 +97,7 @@ export const SellerMypageModifyProfile = () => {
   const category = useCustomSelect('category');
   const style = useCustomSelect('style');
   const type = useCustomSelect('type');
-  // 시간 설정은 나중에....ㅠㅠ
+
   const availableTime = useCustomSelect('time');
 
   const letterPrice = useInput('');

--- a/src/pages/Seller/SellerMyPageViewProfile.tsx
+++ b/src/pages/Seller/SellerMyPageViewProfile.tsx
@@ -33,8 +33,11 @@ export const SellerMypageViewProfile = () => {
           setIsEvaluationPending(true);
         }
         const profileRes: any = await getProfiles();
-        if (profileRes?.response?.status === 404) {
+        if (profileRes?.response?.status === 403) {
           alert('마인더 인증을 통과한 뒤 판매 정보를 등록할 수 있습니다.');
+          navigate('/minder/mypage');
+        } else if (profileRes?.response?.status === 404) {
+          alert('등록되지 않은 회원 정보입니다.');
           navigate('/minder/mypage');
         }
         setProfile(profileRes.data);

--- a/src/utils/isIncludeSpecialLetter.ts
+++ b/src/utils/isIncludeSpecialLetter.ts
@@ -9,7 +9,7 @@ export const isIncludeSpecialLetter = (str: string) => {
 };
 
 export const isIncludeSpecialLetterOneLiner = (str: string) => {
-  var specialCharacterRegex = /[\{\}\[\]\/,;|\)*~`^\-_+<>@\#$%&\\\=\(\'\"]/g;
+  var specialCharacterRegex = /[\{\}\[\]\/;|\)*~`^\-_+<>@\#$%&\\\=\(\'\"]/g;
   if (specialCharacterRegex.test(str)) {
     return true;
   } else {


### PR DESCRIPTION
## Checklist

<br>

- [x] 올바른 브랜치에 PR을 보내도록 설정하였나요?
- [x] PR의 라벨을 올바르게 달았나요?

<br>

## Description

<br>

사소하면서 치명적인 오류 2가지 고쳤습니다. (이슈 참고부탁드립니다!) 

1. 검색 결과 페이지에서 쿼리 파라미터로 검색어를 조회하는데,  SearchRecent.tsx  에서 최근 검색어를 전역변수(recoil)로 보내주고 있어서  쿼리스트링 형태로 빠르게 수정해 보았습니다~
2. 마인더 입장에서 로그인 하지 않거나 마인더 인증 통과 전에 공개상담 탭 접근 했을 경우 alert 띄우면서 공개상담 탭의 활성화를 막았습니다.
<br>

## Related Issues

<br>
#237 
#239 
<br>

## To Reveiwer

<br>
가볍게 봐주세용
<br>
