### PR TITLE
[Hotfix] 상담 종료시 상담 카드 리뷰 안뜨는 이슈 수정

### DIFF
--- a/src/components/Buyer/Common/ConsultCard.tsx
+++ b/src/components/Buyer/Common/ConsultCard.tsx
@@ -117,7 +117,7 @@ export const ConsultCard = ({
           </div>
         </ConsultStateBox>
       </ConsultContent>
-      {reviewCompleted && (
+      {!reviewCompleted && (
         <Button
           text="리뷰 작성하기"
           height="4.2rem"


### PR DESCRIPTION
## Checklist

<br>

- [X] 올바른 브랜치에 PR을 보내도록 설정하였나요?
- [X] PR의 라벨을 올바르게 달았나요?

<br>

## Description

<br>
상담 종료시 상담 카드 리뷰 안뜨는 이슈 수정
<br>

## Related Issues

<br>
#241 
<br>

## To Reveiwer

<br>
boolean값을 반대로 체크하고 있었네요...!
<br>
