### PR TITLE
[Hotfix] 이용 가능한 상담 방식에 대한 요금만 보이도록 수정

### DIFF
--- a/src/components/Buyer/BuyerCounselorProfile/CounselorExp.tsx
+++ b/src/components/Buyer/BuyerCounselorProfile/CounselorExp.tsx
@@ -1,9 +1,18 @@
 import styled from 'styled-components';
 import { Grey1, Grey3 } from 'styles/color';
 import { Body1, Body2 } from 'styles/font';
+
+//
+//
+//
+
 interface CounselorExpProps {
   experience: string;
 }
+
+//
+//
+//
 
 export const CounselorExp = ({ experience }: CounselorExpProps) => {
   const formattedMessage = (message: string | null): JSX.Element[] | null => {
@@ -16,6 +25,11 @@ export const CounselorExp = ({ experience }: CounselorExpProps) => {
         ))
       : null;
   };
+
+  //
+  //
+  //
+
   return (
     <Wrapper>
       <Body1 color={Grey3}>경험 소개</Body1>
@@ -25,6 +39,7 @@ export const CounselorExp = ({ experience }: CounselorExpProps) => {
     </Wrapper>
   );
 };
+
 const Wrapper = styled.div`
   padding: 1.2rem 2rem 3rem 2rem;
   margin-bottom: 5.2rem;

--- a/src/components/Buyer/BuyerCounselorProfile/CounselorInfo.tsx
+++ b/src/components/Buyer/BuyerCounselorProfile/CounselorInfo.tsx
@@ -3,12 +3,22 @@ import { Grey1, Grey3, Grey6 } from 'styles/color';
 import { Body3 } from 'styles/font';
 import { convertTimeToString } from 'utils/convertTimeToString';
 import { ConsultTimes } from 'utils/type';
+
+//
+//
+//
+
 interface CounselorInfoProps {
   consultType: string[];
   letterPrice: number;
   chattingPrice: number;
   consultTimes: ConsultTimes;
 }
+
+//
+//
+//
+
 export const CounselorInfo = ({
   consultType,
   letterPrice,
@@ -63,14 +73,23 @@ export const CounselorInfo = ({
       </div>
       <div className="row3">
         <Body3 color={Grey3}>상담료</Body3>
-        <Body3 color={Grey1}>
-          편지 1건 {letterPrice}원<br />
-          실시간 30분당 {chattingPrice}원
-        </Body3>
+        <div>
+          {letterPrice !== undefined ? (
+            <Body3 color={Grey1}>
+              편지 1건 {letterPrice.toLocaleString()}원
+            </Body3>
+          ) : null}
+          {chattingPrice !== undefined ? (
+            <Body3 color={Grey1}>
+              채팅 30분당 {chattingPrice.toLocaleString()}원
+            </Body3>
+          ) : null}
+        </div>
       </div>
     </Wrapper>
   );
 };
+
 const Wrapper = styled.div`
   padding: 1.6rem 2rem 1.2rem 5%;
   display: flex;

--- a/src/components/Buyer/Common/ReadyConsultCard.tsx
+++ b/src/components/Buyer/Common/ReadyConsultCard.tsx
@@ -53,7 +53,7 @@ export const ReadyConsultCard = ({
   //보내는 동안 중복 클릭 방지
   const [isSending, setIsSending] = useState<boolean>(false);
   //찜하기 업데이트
-  const handleBookmark = async (e: React.MouseEvent<HTMLElement>) => {
+  const handleBookmark = async (e: React.MouseEvent<SVGSVGElement>) => {
     e.stopPropagation();
     if (isSending) {
       return;
@@ -73,7 +73,7 @@ export const ReadyConsultCard = ({
       setIsSaved(true);
     }
   };
-  const handleUnBookmark = async (e: React.MouseEvent<HTMLElement>) => {
+  const handleUnBookmark = async (e: React.MouseEvent<SVGSVGElement>) => {
     e.stopPropagation();
     if (isSending) {
       return;
@@ -218,6 +218,7 @@ export const ReadyConsultCard = ({
     </Wrapper>
   );
 };
+
 const Wrapper = styled.div`
   width: 89%;
   border-radius: 0.8rem;


### PR DESCRIPTION
## Checklist

<br>

- [X] 올바른 브랜치에 PR을 보내도록 설정하였나요?
- [X] PR의 라벨을 올바르게 달았나요?

<br>

## Description

<br>
이용 가능한 상담 방식에 대한 요금만 보이도록 수정
<br>

## Related Issues

<br>
#240 
<br>

## To Reveiwer

<br>
간단하게 삼항연산자로 수정하였습니다~
<br>
