### PR TITLE
[Refactor] url을 통한 unsubscribe에서 StompSubscription으로 리펙토링

### DIFF
--- a/src/components/Buyer/BuyerChat/BuyerChatSection.tsx
+++ b/src/components/Buyer/BuyerChat/BuyerChatSection.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable array-callback-return */
 import styled from 'styled-components';
 import {
   Black,
@@ -95,6 +96,7 @@ const BuyerChatSection = ({
           }}
         ></div>
       )}
+
       {messages.map((value, index) => {
         let isLastIndex = index === messages.length - 1;
         //iscustomer가 true인거 customer message, 시작

--- a/src/components/Buyer/BuyerConsult/BuyerConsultChatSection.tsx
+++ b/src/components/Buyer/BuyerConsult/BuyerConsultChatSection.tsx
@@ -126,7 +126,7 @@ export const BuyerConsultChatSection = ({
     };
 
     const subscribeChatList = () => {
-      if (stompClient.current) {
+      if (stompClient.current?.connected) {
         // 이거 전에 먼저 userId 를 받고 userId 기준으로 subscribe 한다.
         const userSubscription = stompClient.current.subscribe(
           `/queue/chattings/connect/customers/${userIdRef.current}`,
@@ -154,7 +154,6 @@ export const BuyerConsultChatSection = ({
               }
             });
             if (response.userId !== null) {
-              // userIdRef.current = response.userId;
               //채팅방 생성, 종료 readid tab 갱신
               const notificationSubscribe = stompClient.current?.subscribe(
                 '/queue/chattings/notifications/customers/' + response.userId,
@@ -200,7 +199,7 @@ export const BuyerConsultChatSection = ({
 
     return () => {
       // eslint-disable-next-line react-hooks/exhaustive-deps
-      if (stompClient.current) {
+      if (stompClient.current?.connected) {
         ConsultSubscriptions.current.forEach((subscription) => {
           subscription.unsubscribe();
         });

--- a/src/components/Common/AppContainer.tsx
+++ b/src/components/Common/AppContainer.tsx
@@ -5,9 +5,18 @@ import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import { Grey6, White } from 'styles/color';
 import { scrollLockState } from 'utils/atom';
+
+//
+//
+//
+
 interface AppContainerProps {
   children: React.ReactNode;
 }
+
+//
+//
+//
 
 export const AppContainer = ({ children }: AppContainerProps) => {
   useViewResize();
@@ -15,6 +24,10 @@ export const AppContainer = ({ children }: AppContainerProps) => {
   const scrollLock = useRecoilValue<boolean>(scrollLockState);
   var { pathname } = useLocation();
   const [isGray, setIsGray] = useState(false);
+
+  //
+  //
+  //
   useEffect(() => {
     if (
       pathname === '/minder/mypage/viewProfile' ||
@@ -30,12 +43,18 @@ export const AppContainer = ({ children }: AppContainerProps) => {
       setIsGray(false);
     }
   }, [pathname]);
+
+  //
+  //
+  //
+
   return (
     <StyledApp $isGray={isGray} $scrollLock={scrollLock}>
       {children}
     </StyledApp>
   );
 };
+
 const StyledApp = styled.div<{ $isGray: boolean; $scrollLock: boolean }>`
   height: calc(var(--vh, 1vh) * 100);
   @media (min-width: 768px) {

--- a/src/contexts/StompContext.tsx
+++ b/src/contexts/StompContext.tsx
@@ -9,8 +9,6 @@ import React, {
 } from 'react';
 import SockJs from 'sockjs-client';
 import { CompatClient, IFrame, Stomp } from '@stomp/stompjs';
-import { useRecoilState } from 'recoil';
-import { isCustomerState } from 'utils/atom';
 import { useLocation } from 'react-router-dom';
 import { postPublicReissue } from 'api/post';
 import { getCookie, setCookie } from 'utils/cookie';
@@ -27,8 +25,6 @@ interface StompProviderType {
   stompClient: MutableRefObject<CompatClient | null>;
   connectChat: () => void;
   isConnected: boolean;
-  // disconnect: () => void;
-  // sendMessage: (message: Message) => void;
 }
 
 //
@@ -52,15 +48,18 @@ export const StompProvider: React.FC<{ children: ReactNode }> = ({
 }) => {
   const stompClient = useRef<CompatClient | null>(null);
   const { pathname } = useLocation();
-  const [isCustomer, setIsCustomer] = useRecoilState(isCustomerState);
-  const [isConnected, setIsConnected] = useState<boolean>(false);
 
-  // 옯바른 소켓 연결을 위해 경로에 따라 마인더, Seller 구분
-  if (pathname.includes('/minder')) {
-    setIsCustomer(false);
-  } else {
-    setIsCustomer(true);
-  }
+  const getIsCustomer = () => {
+    if (pathname.includes('/minder')) {
+      return false;
+    } else {
+      return true;
+    }
+  };
+
+  const currentIsCustomer = getIsCustomer();
+
+  const [isConnected, setIsConnected] = useState<boolean>(false);
 
   const reissueToken = async () => {
     try {
@@ -82,7 +81,6 @@ export const StompProvider: React.FC<{ children: ReactNode }> = ({
    *
    */
   const connectChat = () => {
-    setIsConnected(false);
     const socket = new SockJs(process.env.REACT_APP_CHAT_URL + '/chat');
     stompClient.current = Stomp.over(() => {
       return socket;
@@ -91,12 +89,13 @@ export const StompProvider: React.FC<{ children: ReactNode }> = ({
     stompClient.current.connect(
       {
         Authorization: getCookie('accessToken'),
-        isCustomer: isCustomer,
+        isCustomer: currentIsCustomer,
       },
       (frame: IFrame) => {
         console.log('Connected: ' + frame);
       },
       (error: any) => {
+        console.log(error);
         setIsConnected(false);
         if (error.headers.message === 'UNAUTHORIZED') {
           reissueToken();
@@ -119,6 +118,8 @@ export const StompProvider: React.FC<{ children: ReactNode }> = ({
   //
   //
   //
+
+  // connectChat();
   useEffect(() => {
     connectChat();
     // Provider 언마운트 시 연결 해제
@@ -128,11 +129,10 @@ export const StompProvider: React.FC<{ children: ReactNode }> = ({
           stompClient.current.disconnect();
         }
         setIsConnected(false);
-        console.log('WebSocket disconnected');
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isCustomer]); // 한 번만 실행
+  }, [currentIsCustomer]); // 한 번만 실행
 
   //
   // Context 객체의 Provider 컴포넌트

--- a/src/contexts/StompContext.tsx
+++ b/src/contexts/StompContext.tsx
@@ -131,6 +131,7 @@ export const StompProvider: React.FC<{ children: ReactNode }> = ({
         console.log('WebSocket disconnected');
       }
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isCustomer]); // 한 번만 실행
 
   //

--- a/src/pages/Buyer/BuyerChat.tsx
+++ b/src/pages/Buyer/BuyerChat.tsx
@@ -141,7 +141,6 @@ export const BuyerChat = () => {
    */
   const connectChat = () => {
     if (stompClient.current) {
-      // 구독
       const chatStatusSubscribe = stompClient.current.subscribe(
         '/queue/chattings/customers/' + chatId,
         function (statusUpdate) {

--- a/src/pages/Buyer/BuyerChat.tsx
+++ b/src/pages/Buyer/BuyerChat.tsx
@@ -288,8 +288,6 @@ export const BuyerChat = () => {
         chatErrorSubscribe,
         chatMessagesSubscribe,
       );
-
-      console.log(ChatSubscriptions.current);
     }
   };
 

--- a/src/pages/Buyer/BuyerChat.tsx
+++ b/src/pages/Buyer/BuyerChat.tsx
@@ -29,6 +29,7 @@ export const BuyerChat = () => {
 
   const {
     stompClient,
+    ChatSubscriptions,
     sendMessage,
     sendChatStartResponse,
     sendExitResponse,
@@ -141,12 +142,12 @@ export const BuyerChat = () => {
   const connectChat = () => {
     if (stompClient.current) {
       // 구독
-      stompClient.current.subscribe(
+      const chatStatusSubscribe = stompClient.current.subscribe(
         '/queue/chattings/customers/' + chatId,
         function (statusUpdate) {
           console.log('Status Update: ', statusUpdate.body);
           const arrivedMessage = JSON.parse(statusUpdate.body);
-
+          //TODO: enum 혹은 type으로 뺴기
           if (
             arrivedMessage.chatWebsocketStatus ===
             'COUNSELOR_CHAT_START_REQUEST'
@@ -209,7 +210,7 @@ export const BuyerChat = () => {
         },
       );
       //채팅 시작, 채팅 5분 남았을 때, 채팅 끝났을 때 알림
-      stompClient.current.subscribe(
+      const chatAutoUpdateSubscribe = stompClient.current.subscribe(
         '/queue/chattings/status/customers/' + chatId,
         function (statusAutoUpdate) {
           console.log('Status Auto Update: ', statusAutoUpdate.body);
@@ -251,13 +252,14 @@ export const BuyerChat = () => {
         },
       );
       //에러 핸들링
-      stompClient.current.subscribe(
+      const chatErrorSubscribe = stompClient.current.subscribe(
         '/queue/chattings/exception/customers/' + chatId,
         function (error) {
           console.log('Error: ', error.body);
         },
       );
-      stompClient.current.subscribe(
+
+      const chatMessagesSubscribe = stompClient.current.subscribe(
         '/queue/chatMessages/customers/' + chatId,
         function (message) {
           //받은 message 정보
@@ -279,6 +281,16 @@ export const BuyerChat = () => {
           ]);
         },
       );
+
+      /** subscribe 전부 완료 후, 모두 subscriptions 배열에 push */
+      ChatSubscriptions.current.push(
+        chatStatusSubscribe,
+        chatAutoUpdateSubscribe,
+        chatErrorSubscribe,
+        chatMessagesSubscribe,
+      );
+
+      console.log(ChatSubscriptions.current);
     }
   };
 
@@ -362,18 +374,15 @@ export const BuyerChat = () => {
     //관측 가능
     preventRef.current = true;
     return () => {
+      // eslint-disable-next-line react-hooks/exhaustive-deps
       if (stompClient.current && stompClient.current?.connected) {
-        stompClient.current.unsubscribe('/queue/chattings/customers/' + chatId);
-        stompClient.current.unsubscribe(
-          '/queue/chattings/status/customers/' + chatId,
-        );
-        stompClient.current.unsubscribe(
-          '/queue/chattings/exception/customers/' + chatId,
-        );
         // eslint-disable-next-line react-hooks/exhaustive-deps
-        stompClient.current.unsubscribe(
-          '/queue/chatMessages/customers/' + chatId,
-        );
+        ChatSubscriptions.current.forEach((subscription) => {
+          subscription.unsubscribe();
+        });
+
+        // Clear the array after unsubscribing
+        ChatSubscriptions.current = [];
         sendExitResponse();
       }
     };

--- a/src/utils/atom.ts
+++ b/src/utils/atom.ts
@@ -2,10 +2,6 @@ import { atom } from 'recoil';
 import { recoilPersist } from 'recoil-persist';
 const { persistAtom } = recoilPersist();
 
-export const isCustomerState = atom({
-  key: 'isCustomerState',
-  default: true,
-});
 //퍈매 정보 수정 페이지 : 상담 카테고리 선택 모달
 export const isCategoryModalOpenState = atom({
   key: 'categoryModalOpenState',

--- a/src/ws/useCounselorChat.ts
+++ b/src/ws/useCounselorChat.ts
@@ -1,4 +1,6 @@
+import { StompSubscription } from '@stomp/stompjs';
 import { useStompContext } from 'contexts/StompContext';
+import { useRef } from 'react';
 
 //
 //
@@ -6,6 +8,8 @@ import { useStompContext } from 'contexts/StompContext';
 
 const useCounselorChat = (chatId: string) => {
   const { stompClient } = useStompContext();
+
+  const ChatSubscriptions = useRef<StompSubscription[]>([]);
 
   const sendMessage = (content: string) => {
     if (stompClient.current && stompClient.current.connected) {
@@ -45,6 +49,7 @@ const useCounselorChat = (chatId: string) => {
 
   return {
     stompClient,
+    ChatSubscriptions,
     sendMessage,
     sendChatStartRequest,
     sendExitResponse,

--- a/src/ws/useCustomerChat.ts
+++ b/src/ws/useCustomerChat.ts
@@ -1,4 +1,6 @@
+import { StompSubscription } from '@stomp/stompjs';
 import { useStompContext } from 'contexts/StompContext';
+import { useRef } from 'react';
 
 //
 //
@@ -6,6 +8,8 @@ import { useStompContext } from 'contexts/StompContext';
 
 const useCustomerChat = (chatId: string) => {
   const { stompClient } = useStompContext();
+
+  const ChatSubscriptions = useRef<StompSubscription[]>([]);
 
   const sendMessage = (content: string) => {
     if (stompClient.current && stompClient.current.connected) {
@@ -45,6 +49,7 @@ const useCustomerChat = (chatId: string) => {
 
   return {
     stompClient,
+    ChatSubscriptions,
     sendMessage,
     sendChatStartResponse,
     sendExitResponse,


### PR DESCRIPTION
## Checklist

<br>

- [X] 올바른 브랜치에 PR을 보내도록 설정하였나요?
- [X] PR의 라벨을 올바르게 달았나요?

<br>

## Description

<br>
url을 통한 unsubscribe는 해당 subscription 객체를 unsubscribe 하기 때문에 사용 시 여러개의 중복된 subscribe가 발생하는 이슈가 있었습니다. 
 이를 해겷하기 위해 StompSubscription type ref 배열을 이용하여 unsubscribe 하도록 리펙토링하였습니다.
<br>

## Related Issues

<br>
#269 
<br>

## To Reveiwer

<br>
해당 브랜치에서 채팅 동작 테스트 및 개발자도구로 메세지가 한번에 여러개 들어오는 케이스가 없는지 확인 부탁드립니다~!
<br>
