### PR TITLE
[Bug] 공개상담 detail 페이지(인기순/최신순) 헤더 스크롤 시 사라지는 이슈 해결

### DIFF
--- a/src/components/Common/AppHeader.tsx
+++ b/src/components/Common/AppHeader.tsx
@@ -1,7 +1,9 @@
 import { ReactComponent as Back } from 'assets/icons/icon-back.svg';
 import styled from 'styled-components';
+import { APP_HEADER_HEIGHT, APP_WIDTH } from 'styles/AppStyle';
 import { Grey1, Grey6, White } from 'styles/color';
 import { Heading } from 'styles/font';
+import { Space } from './Space';
 
 //
 //
@@ -20,10 +22,13 @@ interface AppHeaderProps {
 /** Header with title, backspace button. */
 const AppHeader = ({ title, border = true, onBackClick }: AppHeaderProps) => {
   return (
-    <HeaderWrapper border={border}>
-      <BackIcon onClick={onBackClick} />
-      <Heading color={Grey1}>{title}</Heading>
-    </HeaderWrapper>
+    <>
+      <HeaderWrapper border={border}>
+        <BackIcon onClick={onBackClick} />
+        <Heading color={Grey1}>{title}</Heading>
+      </HeaderWrapper>
+      <Space height={APP_HEADER_HEIGHT} />
+    </>
   );
 };
 
@@ -34,7 +39,7 @@ export default AppHeader;
 //
 
 export const HeaderWrapper = styled.header<{ border?: boolean }>`
-  height: 5.2rem;
+  height: ${APP_HEADER_HEIGHT};
   background-color: ${White};
   position: relative;
   ${(props) =>
@@ -44,7 +49,12 @@ export const HeaderWrapper = styled.header<{ border?: boolean }>`
   display: flex;
   justify-content: center;
   align-items: center;
-  position: sticky;
+  position: fixed;
+  width: 100%;
+
+  @media (min-width: 768px) {
+    width: ${APP_WIDTH};
+  }
   top: 0;
   z-index: 999;
 `;

--- a/src/styles/AppStyle.ts
+++ b/src/styles/AppStyle.ts
@@ -1,1 +1,3 @@
 export const APP_WIDTH = '37.5rem';
+
+export const APP_HEADER_HEIGHT = '5.2rem';


### PR DESCRIPTION
## Checklist

<br>

- [X] 올바른 브랜치에 PR을 보내도록 설정하였나요?
- [X] PR의 라벨을 올바르게 달았나요?

<br>

## Description

<br>

공개상담 detail 페이지(인기순/최신순) 헤더 스크롤 시 사라지는 이슈 해결

* AppHeader를 fixed로 수정하고, `APP_HEADER_HEIGHT` 추가하였습니다.

<br>

## Related Issues

<br>
#303 
<br>

## To Reveiwer

<br>

* header도 기존의 방식 말고 `AppHeader.tsx` 사용하시면 될 것 같습니다!

<br>
