### PR TITLE
[Feat] 찜 목록 페이지 infinite query로 마이그레이션

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -6,7 +6,7 @@ labels: "\U0001F4AB feat"
 assignees: ''
 ---
 
-## Describtion
+## Description
 
 <br>
 Issue 내용을 작성해주세요.

--- a/src/components/Buyer/BuyerSavedCounselor.tsx/SavedCounselorResults.tsx
+++ b/src/components/Buyer/BuyerSavedCounselor.tsx/SavedCounselorResults.tsx
@@ -3,25 +3,103 @@ import { WishlistDataType } from 'utils/type';
 import { AppendCategoryType } from 'utils/AppendCategoryType';
 import { consultStyleToCharNum } from 'utils/convertStringToCharNum';
 import CounselorCard from 'components/Common/CounselorCard';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { postWishLists } from 'api/post';
+import { useMemo } from 'react';
+import useInfiniteObserver from 'hooks/useInfiniteObserver';
+import { Space } from 'components/Common/Space';
+import { LoadingSpinner } from 'utils/LoadingSpinner';
+import EmptySection from 'components/Common/EmptySection';
 
 //
 //
 //
 
-interface SavedCounselorResultsProps {
-  wishlistData: WishlistDataType[];
-}
+const INFINITE_POST_WISH_LISTS_QUERY_KEY = 'infinitePostWishLists';
+
+const WISH_LIST_PER_PAGE = 4;
 
 //
 //
 //
 
-export const SavedCounselorResults = ({
-  wishlistData,
-}: SavedCounselorResultsProps) => {
+export const SavedCounselorResults = () => {
+  //
+  //
+  //
+  const {
+    data: wishlistData,
+    fetchNextPage,
+    hasNextPage,
+    isFetching,
+    isFetchingNextPage,
+    isLoadingError,
+  } = useInfiniteQuery<WishlistDataType[]>({
+    queryKey: [INFINITE_POST_WISH_LISTS_QUERY_KEY],
+    queryFn: async ({ pageParam }) =>
+      await postWishLists(pageParam).then((res: any) => res.data),
+    initialPageParam: {
+      wishlistId: 0,
+      updatedAt: '',
+    },
+    getNextPageParam: (lastPage) => {
+      if (lastPage.length < WISH_LIST_PER_PAGE) {
+        return undefined;
+      }
+
+      const lastItem = lastPage[lastPage.length - 1];
+
+      return {
+        wishlistId: lastItem.wishlistId,
+        updatedAt: lastItem.updatedAt,
+      };
+    },
+  });
+
+  const wishlists = useMemo(
+    () => wishlistData?.pages.flatMap((wishlist) => wishlist) ?? [],
+    [wishlistData],
+  );
+
+  const { observerElem } = useInfiniteObserver({
+    fetchNextPage,
+    hasNextPage,
+    isFetching,
+    isFetchingNextPage,
+    isLoadingError,
+  });
+
+  //
+  //
+  //
+
+  if (isFetching && !isFetchingNextPage) {
+    return (
+      <div
+        style={{
+          height: '70vh',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (wishlists.length === 0) {
+    return (
+      <EmptySection
+        title="아직 찜한 마인더가 없어요."
+        subtitle={`관심 있는 마인더를 찜하고\n더욱 편리하게 상담하세요.`}
+      />
+    );
+  }
+
   return (
     <Wrapper>
-      {wishlistData.map((value) => {
+      {wishlists.map((value) => {
         return (
           <CounselorCard
             key={value.wishlistId}
@@ -41,6 +119,8 @@ export const SavedCounselorResults = ({
           />
         );
       })}
+      <div ref={observerElem} />
+      <Space height="3.5rem" />
     </Wrapper>
   );
 };

--- a/src/components/Buyer/BuyerSavedCounselor.tsx/SavedCounselorResults.tsx
+++ b/src/components/Buyer/BuyerSavedCounselor.tsx/SavedCounselorResults.tsx
@@ -115,7 +115,6 @@ export const SavedCounselorResults = () => {
             level={value.level}
             rating={value.ratingAverage}
             totalReview={value.totalReview}
-            isSavedCounselorPage={true}
           />
         );
       })}

--- a/src/components/Buyer/BuyerSavedCounselor.tsx/SavedOpenConsultResults.tsx
+++ b/src/components/Buyer/BuyerSavedCounselor.tsx/SavedOpenConsultResults.tsx
@@ -1,19 +1,102 @@
 import { openConsultApiObject } from 'pages/Buyer/BuyerConsult';
-import React from 'react';
 import styled from 'styled-components';
 import SavedOpenConsultCard from './SavedOpenConsultCard';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { getPostScraps } from 'api/get';
+import { useMemo } from 'react';
+import useInfiniteObserver from 'hooks/useInfiniteObserver';
+import { Space } from 'components/Common/Space';
+import { LoadingSpinner } from 'utils/LoadingSpinner';
+import EmptySection from 'components/Common/EmptySection';
 
-interface SavedOpenConsultResultsProps {
-  openConsultList: openConsultApiObject[];
-}
-function SavedOpenConsultResults({
-  openConsultList,
-}: SavedOpenConsultResultsProps) {
+//
+//
+//
+
+const INFINITE_POST_SCRAPS_QUERY_KEY = 'infiniteGetPostScraps';
+
+const POST_SCRAPS_PER_PAGE = 6;
+
+//
+//
+//
+
+function SavedOpenConsultResults() {
+  //
+  //
+  //
+  const {
+    data: openConsults,
+    fetchNextPage,
+    hasNextPage,
+    isFetching,
+    isFetchingNextPage,
+    isLoadingError,
+  } = useInfiniteQuery<openConsultApiObject[]>({
+    queryKey: [INFINITE_POST_SCRAPS_QUERY_KEY],
+    queryFn: async ({ pageParam }) =>
+      await getPostScraps({ params: pageParam }).then((res: any) => res.data),
+    initialPageParam: {
+      postScrapId: 0,
+      scrappedAt: new Date().toISOString().slice(0, 19),
+    },
+    getNextPageParam: (lastPage) => {
+      if (lastPage.length < POST_SCRAPS_PER_PAGE) {
+        return undefined;
+      }
+
+      const lastItem = lastPage[lastPage.length - 1];
+
+      return {
+        postScrapId: lastItem.postScrapId,
+        scrappedAt: lastItem.scrappedAt,
+      };
+    },
+  });
+
+  const openConsultList = useMemo(
+    () => openConsults?.pages.flatMap((consult) => consult) ?? [],
+    [openConsults],
+  );
+
+  const { observerElem } = useInfiniteObserver({
+    fetchNextPage,
+    hasNextPage,
+    isFetching,
+    isFetchingNextPage,
+    isLoadingError,
+  });
+
+  //
+  //
+  //
+
+  if (isFetching && !isFetchingNextPage) {
+    return (
+      <div
+        style={{
+          height: '70vh',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (openConsultList.length === 0) {
+    return <EmptySection title="아직 저장한 공개상담이 없어요." />;
+  }
+
   return (
     <Wrapper>
       {openConsultList.map((card) => (
         <SavedOpenConsultCard item={card} />
       ))}
+      <div ref={observerElem} />
+      <Space height="3.5rem" />
     </Wrapper>
   );
 }
@@ -22,7 +105,10 @@ const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1.2rem;
+  box-sizing: border-box;
+  padding: 0 2rem;
   align-items: center;
   width: 100%;
 `;
+
 export default SavedOpenConsultResults;

--- a/src/components/Common/CounselorCard.tsx
+++ b/src/components/Common/CounselorCard.tsx
@@ -236,10 +236,6 @@ const CounselorCard = ({
   //
   //
 
-  if (isSavedCounselorPage && !isSaved) {
-    return null;
-  }
-
   return (
     <Wrapper>
       {renderIntroSection()}

--- a/src/components/Common/CounselorCard.tsx
+++ b/src/components/Common/CounselorCard.tsx
@@ -34,7 +34,6 @@ interface CounselorCardProps {
   totalConsult?: number;
   isRealtime?: boolean;
   consultStyle?: number;
-  isSavedCounselorPage?: boolean;
 }
 
 //
@@ -74,7 +73,6 @@ const CounselorCard = ({
   consultStyle,
   totalConsult,
   isRealtime,
-  isSavedCounselorPage = false,
 }: CounselorCardProps) => {
   const navigate = useNavigate();
 

--- a/src/pages/Buyer/BuyerSavedCounselor.tsx
+++ b/src/pages/Buyer/BuyerSavedCounselor.tsx
@@ -1,21 +1,14 @@
-import { postWishLists } from 'api/post';
 import { SavedCounselorResults } from 'components/Buyer/BuyerSavedCounselor.tsx/SavedCounselorResults';
 import { BackIcon, HeaderWrapper } from 'components/Buyer/Common/Header';
 import { Space } from 'components/Common/Space';
-import { useLayoutEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Grey1 } from 'styles/color';
-import { Body2, Heading } from 'styles/font';
-import { WishlistDataType } from 'utils/type';
-import { ReactComponent as Empty } from 'assets/icons/graphic-noting.svg';
-import styled from 'styled-components';
-import useIntersectionObserver from 'hooks/useIntersectionObserver';
+import { Heading } from 'styles/font';
+
 import Divider2 from 'components/Common/Divider2';
-import { openConsultApiObject } from './BuyerConsult';
-import { getPostScraps } from 'api/get';
+
 import SavedOpenConsultResults from 'components/Buyer/BuyerSavedCounselor.tsx/SavedOpenConsultResults';
-import { LoadingSpinner } from 'utils/LoadingSpinner';
-import { Flex } from 'components/Common/Flex';
 
 //
 //
@@ -24,134 +17,13 @@ import { Flex } from 'components/Common/Flex';
 export const BuyerSavedCounselor = () => {
   const navigate = useNavigate();
 
-  const [isInitialLoading, setIsInitialLoading] = useState(true);
-  const [wishlistData, setWishlistData] = useState<WishlistDataType[]>([]);
-  const [openConsultData, setOpenConsultData] = useState<
-    openConsultApiObject[]
-  >([]);
-
-  const [isLastElem, setIsLastElem] = useState<boolean>(false);
   const [tabState, setTabState] = useState<number>(1);
 
-  const preventRef = useRef(true);
-
-  const onIntersect: IntersectionObserverCallback = async (entry) => {
-    if (
-      entry[0].isIntersecting &&
-      !isLastElem &&
-      !isInitialLoading &&
-      preventRef.current
-    ) {
-      preventRef.current = false;
-      if (tabState === 1) {
-        await fetchWishlistData(
-          wishlistData[wishlistData.length - 1].wishlistId,
-          wishlistData[wishlistData.length - 1].updatedAt,
-        );
-      } else if (tabState === 2) {
-        await fetchOpenConsultData(
-          openConsultData[openConsultData.length - 1].postScrapId,
-          openConsultData[openConsultData.length - 1].scrappedAt,
-        );
-      }
-
-      preventRef.current = true;
-    }
-  };
-
-  //현재 대상 및 option을 props로 전달
-  const { setTarget } = useIntersectionObserver({
-    root: null,
-    rootMargin: '0px',
-    threshold: 0.8,
-    onIntersect,
-  });
-
-  /**
-   *
-   */
-  const fetchWishlistData = async (lastId: number, lastUpdateAt: string) => {
-    const body = {
-      wishlistId: lastId,
-      updatedAt: lastUpdateAt,
-    };
-    try {
-      const res: any = await postWishLists(body);
-      if (res.status === 200) {
-        if (res.data.length !== 0) {
-          if (lastId === 0) {
-            setIsInitialLoading(true);
-            setWishlistData(res.data);
-          } else {
-            const updatedReviews = [...wishlistData, ...res.data];
-            setWishlistData(updatedReviews);
-          }
-        } else {
-          setIsLastElem(true);
-        }
-      } else if (res.response.status !== 401) {
-        navigate('/mypage');
-      }
-    } catch (e) {
-      alert(e);
-    } finally {
-      if (lastId === 0) {
-        setIsInitialLoading(false);
-      }
-    }
-  };
-
-  /**
-   *
-   */
-  const fetchOpenConsultData = async (lastId: number, lastUpdateAt: string) => {
-    try {
-      const params = {
-        postScrapId: lastId,
-        scrappedAt: lastUpdateAt,
-      };
-      const res: any = await getPostScraps({ params });
-      if (res.status === 200) {
-        if (res.data.length !== 0) {
-          if (lastId === 0) {
-            setIsInitialLoading(true);
-            setOpenConsultData(res.data);
-          } else {
-            const updatedOpenConsultList = [...openConsultData, ...res.data];
-            setOpenConsultData(updatedOpenConsultList);
-          }
-        } else {
-          setIsLastElem(true);
-        }
-      } else if (res.response.status !== 401) {
-        // navigate('/mypage');
-      }
-    } catch (err) {
-      alert(err);
-    } finally {
-      if (lastId === 0) {
-        setIsInitialLoading(false);
-      }
-    }
-  };
-
-  //
-  //
-  //
-  useLayoutEffect(() => {
-    setIsInitialLoading(true);
-    if (tabState === 1) {
-      fetchWishlistData(0, '');
-    } else if (tabState === 2) {
-      fetchOpenConsultData(0, new Date().toISOString().slice(0, 19));
-    }
-  }, [tabState]);
-
   //
   //
   //
 
-  if (isInitialLoading) {
+  if (tabState === 1) {
     return (
       <>
         <HeaderWrapper>
@@ -163,121 +35,25 @@ export const BuyerSavedCounselor = () => {
           <Heading color={Grey1}>찜 목록</Heading>
         </HeaderWrapper>
         <Divider2 tabState={tabState} setTabState={setTabState} />
-        <div
-          style={{
-            height: '70vh',
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-          }}
-        >
-          <LoadingSpinner />
-        </div>
+        <Space height="1.2rem" />
+        <SavedCounselorResults />
+      </>
+    );
+  } else if (tabState === 2) {
+    return (
+      <>
+        <HeaderWrapper>
+          <BackIcon
+            onClick={() => {
+              navigate('/mypage');
+            }}
+          />
+          <Heading color={Grey1}>찜 목록</Heading>
+        </HeaderWrapper>
+        <Divider2 tabState={tabState} setTabState={setTabState} />
+        <Space height="1.2rem" />
+        <SavedOpenConsultResults />
       </>
     );
   }
-
-  if (tabState === 1) {
-    if (wishlistData.length !== 0) {
-      return (
-        <>
-          <HeaderWrapper>
-            <BackIcon
-              onClick={() => {
-                navigate('/mypage');
-              }}
-            />
-            <Heading color={Grey1}>찜 목록</Heading>
-          </HeaderWrapper>
-          <Divider2 tabState={tabState} setTabState={setTabState} />
-          <Space height="1.2rem" />
-          <div
-            className="save-counselor-list"
-            style={{ height: 'calc(100vh - 11rem)', overflow: 'scroll' }}
-          >
-            <SavedCounselorResults wishlistData={wishlistData} />
-            {!isLastElem ? (
-              <div ref={setTarget} style={{ height: '3.5rem' }} />
-            ) : (
-              <div style={{ height: '3.5rem' }} />
-            )}
-          </div>
-        </>
-      );
-    } else {
-      return (
-        <>
-          <HeaderWrapper>
-            <BackIcon
-              onClick={() => {
-                navigate('/mypage');
-              }}
-            />
-            <Heading color={Grey1}>찜 목록</Heading>
-          </HeaderWrapper>
-          <Divider2 tabState={tabState} setTabState={setTabState} />
-          <EmptyWrapper>
-            <EmptyIcon />
-            <Heading>아직 찜한 마인더가 없어요.</Heading>
-            <Space height="1.5rem" />
-            <Body2>
-              관심 있는 마인더를 찜하고 <br /> 더욱 편리하게 상담하세요.
-            </Body2>
-          </EmptyWrapper>
-        </>
-      );
-    }
-  } else if (tabState === 2) {
-    if (openConsultData.length !== 0) {
-      return (
-        <>
-          <HeaderWrapper>
-            <BackIcon
-              onClick={() => {
-                navigate('/mypage');
-              }}
-            />
-            <Heading color={Grey1}>찜 목록</Heading>
-          </HeaderWrapper>
-          <Divider2 tabState={tabState} setTabState={setTabState} />
-          <Space height="1.2rem" />
-          <Flex direction="column" style={{ padding: '0 2rem' }}>
-            <SavedOpenConsultResults openConsultList={openConsultData} />
-            {!isLastElem ? (
-              <div ref={setTarget} style={{ height: '3.5rem' }} />
-            ) : (
-              <div style={{ height: '3.5rem' }} />
-            )}
-          </Flex>
-        </>
-      );
-    } else {
-      return (
-        <>
-          <HeaderWrapper>
-            <BackIcon
-              onClick={() => {
-                navigate('/mypage');
-              }}
-            />
-            <Heading color={Grey1}>찜 목록</Heading>
-          </HeaderWrapper>
-          <Divider2 tabState={tabState} setTabState={setTabState} />
-          <EmptyWrapper>
-            <EmptyIcon />
-            <Heading>아직 저장한 공개상담이 없어요.</Heading>
-          </EmptyWrapper>
-        </>
-      );
-    }
-  }
 };
-const EmptyWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-`;
-const EmptyIcon = styled(Empty)`
-  margin-top: 20vh;
-  padding: 4.7rem 4.413rem 4.603rem 4.5rem;
-`;


### PR DESCRIPTION
## Checklist

<br>

- [X] 올바른 브랜치에 PR을 보내도록 설정하였나요?
- [X] PR의 라벨을 올바르게 달았나요?

<br>

## Description

<br>

### 찜 목록 페이지 infinite query로 변경

 기존의 목적은 찜을 취소하면 visiblity를 false로 만드는 방식으로 즉각적으로 반영되는 것처럼 구현하였으나, 엠티 뷰가 안보이는 이슈가 있어 infinite query로 마이그레이션하여 해결하려하였습니다.
 
  하지만 query를 invalidate할 때마다 깜빡임 이슈가 있었고, 다른 래퍼런스 페이지 찾아본 결과 좋아요 혹은 스크랩을 취소해도 바로 없어지지 않게 구현이 돼있어, infinite query로만 변경하게 되었습니다.

<br>

## Related Issues

<br>
#350 
<br>

