### PR TITLE
[Hotfix] 편지, 채팅 가격 설정 범위 수정

### DIFF
--- a/src/components/Seller/SellerMyPageModifyProfile/ModifyProfileMainSection.tsx
+++ b/src/components/Seller/SellerMyPageModifyProfile/ModifyProfileMainSection.tsx
@@ -282,11 +282,11 @@ function ModifyProfileMainSection({
               <PriceInput
                 value={letterPrice.value}
                 onChange={letterPrice.onChangePrice}
-                placeholder="1건 당 5,000~50,000"
+                placeholder="1건 당 3,000~30,000"
                 maxLength={6}
                 isError={
-                  parseFloat(letterPrice?.value?.replace(/,/g, '')) < 5000 ||
-                  parseFloat(letterPrice?.value?.replace(/,/g, '')) > 50000
+                  parseFloat(letterPrice?.value?.replace(/,/g, '')) < 3000 ||
+                  parseFloat(letterPrice?.value?.replace(/,/g, '')) > 30000
                     ? true
                     : false
                 }
@@ -457,8 +457,8 @@ function ModifyProfileMainSection({
                 ? true
                 : false) ||
               ((selectType?.includes('편지') &&
-                parseFloat(letterPrice?.value?.replace(/,/g, '')) < 5000) ||
-              parseFloat(letterPrice?.value?.replace(/,/g, '')) > 50000
+                parseFloat(letterPrice?.value?.replace(/,/g, '')) < 3000) ||
+              parseFloat(letterPrice?.value?.replace(/,/g, '')) > 30000
                 ? true
                 : false)
             )

--- a/src/pages/Seller/SellerMyPageModifyProfile.tsx
+++ b/src/pages/Seller/SellerMyPageModifyProfile.tsx
@@ -150,13 +150,13 @@ export const SellerMypageModifyProfile = () => {
           setIsLoading(false);
         } else if (profileLevel?.data?.profileStatus === 'EVALUATION_PENDING') {
           alert('판매 정보 검토 중이니 조금만 기다려주세요!');
-          navigate('/seller/mypage/viewProfile');
+          navigate('/minder/mypage/viewProfile');
         } else {
           const profileRes: any = await getProfiles();
           const data = profileRes.data;
           if (profileRes.response?.status === 404) {
             alert('판매 정보가 등록되어 있지 않습니다.');
-            navigate('/seller/mypage');
+            navigate('/minder/mypage');
           }
           nickname.setValue(data?.nickname);
           category.setViewValue(data?.consultCategories.join(', '));
@@ -189,7 +189,7 @@ export const SellerMypageModifyProfile = () => {
           setIsLoading(false);
         }
       } catch (err) {
-        navigate('/seller/mypage');
+        navigate('/minder/mypage');
         alert(err);
       }
       // accountNum.setValue(profileDummyData.accountNum);


### PR DESCRIPTION
## Checklist

<br>

- [x] 올바른 브랜치에 PR을 보내도록 설정하였나요?
- [x] PR의 라벨을 올바르게 달았나요?

<br>

## Description

<br>
판매 정보 수정에서 편지와 채팅의 가격 설정 범위를 3,000~ 30,000원, 5000~50,000원으로 수정하였습니다.
<br>

## Related Issues

<br>
#354 
<br>

## To Reveiwer

<br>
아직 서버쪽에서 편지 가격 범위가 설정이 안돼서

 https://w1696598846-dky839981.slack.com/archives/C06010RG7PG/p1721184169428489

요청사항 보낸 상태입니다


<br>
