### PR TITLE
feat: remove optional condition to counselor card `totalConsult` (#348)

### DIFF
--- a/src/components/Buyer/BuyerSavedCounselor.tsx/SavedCounselorResults.tsx
+++ b/src/components/Buyer/BuyerSavedCounselor.tsx/SavedCounselorResults.tsx
@@ -115,6 +115,7 @@ export const SavedCounselorResults = () => {
             level={value.level}
             rating={value.ratingAverage}
             totalReview={value.totalReview}
+            totalConsult={value.totalConsult}
           />
         );
       })}

--- a/src/components/Common/CounselorCard.tsx
+++ b/src/components/Common/CounselorCard.tsx
@@ -31,7 +31,7 @@ interface CounselorCardProps {
   isWishList: boolean;
   rating: number;
   totalReview: number;
-  totalConsult?: number;
+  totalConsult: number;
   isRealtime?: boolean;
   consultStyle?: number;
 }
@@ -176,13 +176,8 @@ const CounselorCard = ({
                   <Caption2 color={Grey1}>{'LV. ' + level}</Caption2>
                 </Flex>
                 <Flex gap="0.8rem">
-                  {/* TODO: TotalConsult is changed to optional, because get wishlist do not return total consult. It should be added later */}
-                  {totalConsult ? (
-                    <>
-                      <Body3 color={Grey2}>상담 {totalConsult}회</Body3>
-                      <Divider />
-                    </>
-                  ) : null}
+                  <Body3 color={Grey2}>상담 {totalConsult}회</Body3>
+                  <Divider />
                   <Body3 color={Grey2}>후기 {totalReview}개</Body3>
                   <Divider />
                   <Flex gap="0.2rem">

--- a/src/utils/type.ts
+++ b/src/utils/type.ts
@@ -133,6 +133,7 @@ export type WishlistDataType = {
   nickname: string;
   ratingAverage: number;
   totalReview: number;
+  totalConsult: number;
 };
 
 export interface PaymentInfo {


### PR DESCRIPTION
## Checklist

<br>

- [X] 올바른 브랜치에 PR을 보내도록 설정하였나요?
- [X] PR의 라벨을 올바르게 달았나요?

<br>

## Description

<br>
기존에 찜 목록 리스트에 `totalConsult`(상담 횟수)가 없어서 optional 처리하였는데, api에 추가되어 해당 사항 반영하였습니다.
<br>

## Related Issues

<br>
#348 
<br>

## To Reveiwer

<br>
확인 부탁드립니다!
<br>
