### PR TITLE
[Feat] 마인더 전화번호 입력 시 중복 전화번호 에러 핸들링 로직 추가

### DIFF
--- a/src/api/patch.ts
+++ b/src/api/patch.ts
@@ -50,7 +50,8 @@ export const patchLetterMessageFirstQustion = async (body: any) =>
   await patchInstance('/letterMessages/first-question', body);
 
 export const patchProfiles = async (body: any) =>
-  await patchInstance('counselors/profiles', body);
+  await axiosPatch('counselors/profiles', body);
+
 //Payment Controller
 export const patchPaymentsCustomers = async (paymentId: number) =>
   await patchInstance(`/payments/customers/${paymentId}`);

--- a/src/components/Seller/SellerMyPageModifyProfile/ModifyProfileMainSection.tsx
+++ b/src/components/Seller/SellerMyPageModifyProfile/ModifyProfileMainSection.tsx
@@ -29,7 +29,6 @@ import { BottomButton } from '../Common/BottomButton';
 import { Space } from 'components/Common/Space';
 import { UpdatePopup } from './UpdatePopup';
 import { SelectedTimeList } from './SetChatTimeSection';
-import { InputValidStateType } from 'utils/type';
 
 //
 //
@@ -51,6 +50,9 @@ interface ModifyProfileMainSectionProps {
   oneLiner: any;
   experience: any;
   isNoProfile: boolean;
+  phoneNumber: string;
+  phoneNumberValid: string;
+  handlePhoneNumberChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 //
@@ -67,7 +69,7 @@ const dayEngtoKor: Record<string, string> = {
   SUN: '일',
 };
 
-const MAX_PHONE_NUMBER_LENGTH = 14;
+export const MAX_PHONE_NUMBER_LENGTH = 14;
 
 //
 //
@@ -127,45 +129,11 @@ function ModifyProfileMainSection({
   experience,
   isNoProfile,
   selectAvailableTime,
+  phoneNumber,
+  phoneNumberValid,
+  handlePhoneNumberChange,
 }: ModifyProfileMainSectionProps) {
   const navigate = useNavigate();
-
-  /** Phone Number controller */
-  const [phoneNumber, setPhoneNumber] = React.useState<string>('');
-
-  const [phoneNumberValid, setPhoneNumberValid] =
-    React.useState<InputValidStateType>('none');
-
-  /**
-   *
-   */
-  const handlePhoneNumberChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const phoneNumberRegex = /^\d{3}-\d{3,4}-\d{4}$/;
-
-    let inputValue = e.target.value;
-
-    inputValue = inputValue.replace(/\D/g, '');
-
-    if (inputValue.length <= 3) {
-      setPhoneNumber(inputValue);
-    } else if (inputValue.length <= 7) {
-      setPhoneNumber(inputValue.slice(0, 3) + '-' + inputValue.slice(3));
-    } else if (inputValue.length <= 11) {
-      setPhoneNumber(
-        inputValue.slice(0, 3) +
-          '-' +
-          inputValue.slice(3, 7) +
-          '-' +
-          inputValue.slice(7, 11),
-      );
-    }
-
-    if (phoneNumberRegex.test(inputValue)) {
-      setPhoneNumberValid('valid');
-    } else if (inputValue.length === MAX_PHONE_NUMBER_LENGTH) {
-      setPhoneNumberValid('invalid');
-    }
-  };
 
   const [isCategoryModalOpen, setIsCategoryModalOpen] = useRecoilState(
     isCategoryModalOpenState,

--- a/src/components/Seller/SellerMyPageModifyProfile/UpdatePopup.tsx
+++ b/src/components/Seller/SellerMyPageModifyProfile/UpdatePopup.tsx
@@ -1,10 +1,12 @@
 import { patchProfiles } from 'api/patch';
+import { AxiosError } from 'axios';
 import { useSetRecoilState } from 'recoil';
 import styled from 'styled-components';
 import { APP_WIDTH } from 'styles/AppStyle';
 import { Green, Grey4, LightGreen, White } from 'styles/color';
 import { Body1, Body3 } from 'styles/font';
 import { isSuccessUpdateState, isUpdateModalOpenState } from 'utils/atom';
+import { SharemindErrorResponse } from 'utils/type';
 
 //
 //
@@ -23,6 +25,12 @@ interface UpdatePopupProps {
   selectAvailableTime: any;
   phoneNumber: string;
 }
+
+//
+//
+//
+
+const DUPLICATE_PHONE_NUMBER_ERROR_NAME = 'DUPLICATE_PHONE_NUMBER';
 
 //
 //
@@ -63,16 +71,20 @@ export const UpdatePopup = ({
       phoneNumber: phoneNumber,
     };
     try {
-      const res: any = await patchProfiles(body);
+      await patchProfiles(body);
       setIsUpdateModalOpen(false);
-      if (res.status !== 200) {
-        alert('판매 정보를 올바르게 입력해주세요!');
+
+      setIsSuccess(true);
+    } catch (error) {
+      const _error = error as AxiosError;
+
+      const errorResponseData = _error.response?.data as SharemindErrorResponse;
+
+      if (errorResponseData.errorName === DUPLICATE_PHONE_NUMBER_ERROR_NAME) {
+        alert(errorResponseData.message);
       } else {
-        setIsSuccess(true);
+        alert('판매 정보를 올바르게 입력해주세요!');
       }
-    } catch (err) {
-      alert('오류');
-      console.log(err);
     }
   };
 

--- a/src/pages/Seller/SellerMyPageModifyProfile.tsx
+++ b/src/pages/Seller/SellerMyPageModifyProfile.tsx
@@ -4,7 +4,9 @@ import { Space } from 'components/Common/Space';
 import { CategoryModal } from 'components/Seller/SellerMyPageModifyProfile/CategoryModal';
 import IsOutPopup from 'components/Seller/SellerMyPageModifyProfile/IsOutPopup';
 import { ModifyProfileHeader } from 'components/Seller/SellerMyPageModifyProfile/ModifyProfileHeader';
-import ModifyProfileMainSection from 'components/Seller/SellerMyPageModifyProfile/ModifyProfileMainSection';
+import ModifyProfileMainSection, {
+  MAX_PHONE_NUMBER_LENGTH,
+} from 'components/Seller/SellerMyPageModifyProfile/ModifyProfileMainSection';
 import SetChatTimeSection, {
   SelectedTimeList,
 } from 'components/Seller/SellerMyPageModifyProfile/SetChatTimeSection';
@@ -27,6 +29,7 @@ import {
   isTypeOpenModalState,
   isUpdateModalOpenState,
 } from 'utils/atom';
+import { InputValidStateType } from 'utils/type';
 
 //
 //
@@ -106,6 +109,44 @@ export const SellerMypageModifyProfile = () => {
 
   const oneLiner = useInput('');
   const experience = useInput('');
+
+  /** Phone Number controller */
+  const [phoneNumber, setPhoneNumber] = useState<string>('');
+
+  const [phoneNumberValid, setPhoneNumberValid] =
+    useState<InputValidStateType>('none');
+
+  /**
+   *
+   */
+  const handlePhoneNumberChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const phoneNumberRegex = /^\d{3}-\d{3,4}-\d{4}$/;
+
+    let inputValue = e.target.value;
+
+    inputValue = inputValue.replace(/\D/g, '');
+
+    if (inputValue.length <= 3) {
+      setPhoneNumber(inputValue);
+    } else if (inputValue.length <= 7) {
+      setPhoneNumber(inputValue.slice(0, 3) + '-' + inputValue.slice(3));
+    } else if (inputValue.length <= 11) {
+      setPhoneNumber(
+        inputValue.slice(0, 3) +
+          '-' +
+          inputValue.slice(3, 7) +
+          '-' +
+          inputValue.slice(7, 11),
+      );
+    }
+
+    if (phoneNumberRegex.test(inputValue)) {
+      setPhoneNumberValid('valid');
+    } else if (inputValue.length === MAX_PHONE_NUMBER_LENGTH) {
+      setPhoneNumberValid('invalid');
+    }
+  };
+
   const [isNoProfile, setIsNoProfile] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const navigate = useNavigate();
@@ -158,6 +199,7 @@ export const SellerMypageModifyProfile = () => {
             alert('판매 정보가 등록되어 있지 않습니다.');
             navigate('/minder/mypage');
           }
+          setPhoneNumber(data?.phoneNumber);
           nickname.setValue(data?.nickname);
           category.setViewValue(data?.consultCategories.join(', '));
           setSelectCategory(
@@ -238,6 +280,9 @@ export const SellerMypageModifyProfile = () => {
           selectType={selectType}
           setIsSetChatTime={setIsSetChatTime}
           selectAvailableTime={selectedTimeList}
+          phoneNumber={phoneNumber}
+          phoneNumberValid={phoneNumberValid}
+          handlePhoneNumberChange={handlePhoneNumberChange}
         />
       )}
       {/* 모달 여부 True면.. */}

--- a/src/utils/type.ts
+++ b/src/utils/type.ts
@@ -1,4 +1,13 @@
 //type
+
+/** sharemind error response data type */
+
+export interface SharemindErrorResponse {
+  errorName: string;
+  message: string;
+  timeStamp: string;
+}
+
 //tagA2 상담 상태 type
 export type ConsultState =
   | '답변 대기'


### PR DESCRIPTION
## Checklist

<br>

- [X] 올바른 브랜치에 PR을 보내도록 설정하였나요?
- [X] PR의 라벨을 올바르게 달았나요?

<br>

## Description

<br>

* 전화번호 중복 시 에러 핸들링 로직 추가하였습니다.
* `axiosPatch` 로 수정하면서 기존 error 코드 수정하고, `SharemindErrorResponse` 타입 추가하여 최대한 하드코딩하지 않고, 서버에서 넘겨준 값을 통해 에러 핸들링하도록 수정하였습니다!

<br>

## Related Issues

<br>
#381 
<br>

## To Reveiwer

<br>

서버 저장된 전화번호 data를 초기값으로 설정하기 위해 코드 위치만 수정하였고, 에러 핸들링 부분 수정한 것만 한번 확인해주시면 좋을 것 같습니다!

<br>
