### PR TITLE
[Hotfix] 신고하기 모달을 편지, 공개 상담 페이지에 추가

### DIFF
--- a/src/components/Buyer/BuyerOpenConsultDetail/CommentCard.tsx
+++ b/src/components/Buyer/BuyerOpenConsultDetail/CommentCard.tsx
@@ -200,7 +200,7 @@ const SelectButton = styled.button`
 
 const MoreButton = styled(SettingIcon)`
   cursor: pointer;
-  padding: 0 0.4rem;
+  padding: 0.4rem;
 `;
 
 const LikeButton = styled.div`

--- a/src/components/Buyer/BuyerOpenConsultDetail/CommentCard.tsx
+++ b/src/components/Buyer/BuyerOpenConsultDetail/CommentCard.tsx
@@ -35,6 +35,7 @@ interface CommentCardProps {
   setIsPickPopup: React.Dispatch<React.SetStateAction<boolean>>;
   setPickedCommentId: React.Dispatch<React.SetStateAction<string>>;
   isEndConsult: boolean | undefined;
+  handleMoreButtonClick: () => void;
 }
 
 //
@@ -47,6 +48,7 @@ function CommentCard({
   setPickedCommentId,
   setIsPickPopup,
   isEndConsult,
+  handleMoreButtonClick,
 }: CommentCardProps) {
   const navigate = useNavigate();
 
@@ -125,7 +127,7 @@ function CommentCard({
           <Circle />
           <Caption2>{item.updatedAt}</Caption2>
         </Flex>
-        <SettingIcon style={{ padding: '0 0.4rem' }} />
+        <MoreButton onClick={handleMoreButtonClick} />
       </Flex>
       <Body3 color={Grey1}>{formattedMessage(item.content)}</Body3>
       <Flex justify="flex-end" width="100%">
@@ -194,6 +196,11 @@ const SelectButton = styled.button`
   border-radius: 0.8rem;
   border: 1px solid ${Green};
   background-color: ${LightGreen};
+`;
+
+const MoreButton = styled(SettingIcon)`
+  cursor: pointer;
+  padding: 0 0.4rem;
 `;
 
 const LikeButton = styled.div`

--- a/src/components/Buyer/BuyerOpenConsultDetail/CommentListSection.tsx
+++ b/src/components/Buyer/BuyerOpenConsultDetail/CommentListSection.tsx
@@ -10,8 +10,8 @@ import CommentCard from './CommentCard';
 import { Green, LightGreen, White } from 'styles/color';
 import { Flex } from 'components/Common/Flex';
 import { Caption1 } from 'styles/font';
-import { ChatReportModal } from 'components/Seller/SellerChat/ChatReportModal';
-import { useShowComplaintModal } from 'hooks/useShowComplaintModal';
+import { useShowComplainttModal } from 'hooks/useShowComplaintModal';
+import { ComplaintModal } from 'components/Seller/Common/ComplaintModal';
 
 //
 //
@@ -31,8 +31,11 @@ function CommentListSection() {
   // 선택한 댓글 아이디 (좋아요, 채택)
   const [pickedCommentId, setPickedCommentId] = useState<string>('');
 
-  const { isComplaintModalOpen, handleBackDropClick, handleMoreButtonClick } =
-    useShowComplaintModal();
+  const {
+    isComplaintModalOpen,
+    handleBackDropClick,
+    handleComplaintButtonClick,
+  } = useShowComplainttModal();
 
   /**
    *
@@ -60,7 +63,7 @@ function CommentListSection() {
         isEndConsult={isEndConsult}
         setIsPickPopup={setIsPickPopup}
         setPickedCommentId={setPickedCommentId}
-        handleMoreButtonClick={handleMoreButtonClick}
+        handleMoreButtonClick={handleComplaintButtonClick}
       />
     ));
   };
@@ -117,7 +120,9 @@ function CommentListSection() {
       {isComplaintModalOpen && (
         <>
           <BackDrop onClick={handleBackDropClick} />
-          <ChatReportModal />
+          <ComplaintModal
+            handleComplaintButtonClick={handleComplaintButtonClick}
+          />
         </>
       )}
 

--- a/src/components/Buyer/BuyerOpenConsultDetail/CommentListSection.tsx
+++ b/src/components/Buyer/BuyerOpenConsultDetail/CommentListSection.tsx
@@ -10,6 +10,8 @@ import CommentCard from './CommentCard';
 import { Green, LightGreen, White } from 'styles/color';
 import { Flex } from 'components/Common/Flex';
 import { Caption1 } from 'styles/font';
+import { ChatReportModal } from 'components/Seller/SellerChat/ChatReportModal';
+import { useShowComplaintModal } from 'hooks/useShowComplaintModal';
 
 //
 //
@@ -28,6 +30,9 @@ function CommentListSection() {
   const [isEndConsult, setIsEndConsult] = useState<boolean | undefined>();
   // 선택한 댓글 아이디 (좋아요, 채택)
   const [pickedCommentId, setPickedCommentId] = useState<string>('');
+
+  const { isComplaintModalOpen, handleBackDropClick, handleMoreButtonClick } =
+    useShowComplaintModal();
 
   /**
    *
@@ -55,6 +60,7 @@ function CommentListSection() {
         isEndConsult={isEndConsult}
         setIsPickPopup={setIsPickPopup}
         setPickedCommentId={setPickedCommentId}
+        handleMoreButtonClick={handleMoreButtonClick}
       />
     ));
   };
@@ -106,6 +112,12 @@ function CommentListSection() {
             setIsPickPopup={setIsPickPopup}
             pickedCommentId={pickedCommentId}
           />
+        </>
+      )}
+      {isComplaintModalOpen && (
+        <>
+          <BackDrop onClick={handleBackDropClick} />
+          <ChatReportModal />
         </>
       )}
 

--- a/src/components/Buyer/BuyerOpenConsultDetail/CommentListSection.tsx
+++ b/src/components/Buyer/BuyerOpenConsultDetail/CommentListSection.tsx
@@ -31,11 +31,12 @@ function CommentListSection() {
   // 선택한 댓글 아이디 (좋아요, 채택)
   const [pickedCommentId, setPickedCommentId] = useState<string>('');
 
-  const {
-    isComplaintModalOpen,
-    handleBackDropClick,
-    handleComplaintButtonClick,
-  } = useShowComplainttModal();
+  const { isComplaintModalOpen, handleBackDropClick, handleMoreButtonClick } =
+    useShowComplainttModal();
+
+  const handleComplaintButtonClick = () => {
+    window.open(process.env.REACT_APP_TEMP_CUSTOMER_SERVICE_URL);
+  };
 
   /**
    *
@@ -63,7 +64,7 @@ function CommentListSection() {
         isEndConsult={isEndConsult}
         setIsPickPopup={setIsPickPopup}
         setPickedCommentId={setPickedCommentId}
-        handleMoreButtonClick={handleComplaintButtonClick}
+        handleMoreButtonClick={handleMoreButtonClick}
       />
     ));
   };

--- a/src/components/Seller/Common/ComplaintModal.tsx
+++ b/src/components/Seller/Common/ComplaintModal.tsx
@@ -1,16 +1,20 @@
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 import { ReactComponent as Bar } from 'assets/icons/icon-modal-bar.svg';
 import { White } from 'styles/color';
 import { Button } from 'components/Common/Button';
 import { APP_WIDTH } from 'styles/AppStyle';
 
-//
-//
-//
+///
+///
+///
 
 interface ComplaintModalProps {
   handleComplaintButtonClick: () => void;
 }
+
+///
+///
+///
 
 export const ComplaintModal = ({
   handleComplaintButtonClick,
@@ -32,6 +36,15 @@ export const ComplaintModal = ({
   );
 };
 
+const slideUp = keyframes`
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+`;
+
 const ReportModalWrapper = styled.div`
   position: fixed;
   background-color: ${White};
@@ -39,6 +52,8 @@ const ReportModalWrapper = styled.div`
   box-shadow: 0 -0.2rem 1rem 0 rgba(0, 0, 0, 0.1);
   bottom: 0;
   width: 100%;
+  z-index: 10000;
+  animation: ${slideUp} 0.3s ease-out;
 
   @media (min-width: 768px) {
     width: ${APP_WIDTH};
@@ -49,7 +64,7 @@ const ReportModalWrapper = styled.div`
     display: flex;
     justify-content: center;
   }
-  z-index: 10000;
+
   .content-wrapper {
     padding: 0.4rem 2rem 0.8rem 2rem;
     box-sizing: border-box;

--- a/src/components/Seller/Common/ComplaintModal.tsx
+++ b/src/components/Seller/Common/ComplaintModal.tsx
@@ -1,0 +1,61 @@
+import styled from 'styled-components';
+import { ReactComponent as Bar } from 'assets/icons/icon-modal-bar.svg';
+import { White } from 'styles/color';
+import { Button } from 'components/Common/Button';
+import { APP_WIDTH } from 'styles/AppStyle';
+
+//
+//
+//
+
+interface ComplaintModalProps {
+  handleComplaintButtonClick: () => void;
+}
+
+export const ComplaintModal = ({
+  handleComplaintButtonClick,
+}: ComplaintModalProps) => {
+  return (
+    <ReportModalWrapper>
+      <div className="bar-wrapper">
+        <BarIcon />
+      </div>
+      <div className="content-wrapper">
+        <Button
+          text="신고하기"
+          width="100%"
+          height="5.2rem"
+          onClick={handleComplaintButtonClick}
+        />
+      </div>
+    </ReportModalWrapper>
+  );
+};
+
+const ReportModalWrapper = styled.div`
+  position: fixed;
+  background-color: ${White};
+  border-radius: 2rem 2rem 0 0;
+  box-shadow: 0 -0.2rem 1rem 0 rgba(0, 0, 0, 0.1);
+  bottom: 0;
+  width: 100%;
+
+  @media (min-width: 768px) {
+    width: ${APP_WIDTH};
+  }
+
+  .bar-wrapper {
+    height: 1.9rem;
+    display: flex;
+    justify-content: center;
+  }
+  z-index: 10000;
+  .content-wrapper {
+    padding: 0.4rem 2rem 0.8rem 2rem;
+    box-sizing: border-box;
+  }
+`;
+
+const BarIcon = styled(Bar)`
+  margin-top: 0.8rem;
+`;

--- a/src/components/Seller/SellerChat/ChatReportModal.tsx
+++ b/src/components/Seller/SellerChat/ChatReportModal.tsx
@@ -19,7 +19,9 @@ export const ChatReportModal = () => {
           text="신고하기"
           width="100%"
           height="5.2rem"
-          onClick={() => {}}
+          onClick={() => {
+            window.open(process.env.REACT_APP_TEMP_CUSTOMER_SERVICE_URL);
+          }}
         />
       </div>
     </ChatReportModalWrapper>
@@ -43,7 +45,7 @@ const ChatReportModalWrapper = styled.div`
     display: flex;
     justify-content: center;
   }
-  z-index: 100;
+  z-index: 10000;
   .content-wrapper {
     padding: 0.4rem 2rem 0.8rem 2rem;
     box-sizing: border-box;

--- a/src/components/Seller/SellerLetter/LetterHeader.tsx
+++ b/src/components/Seller/SellerLetter/LetterHeader.tsx
@@ -7,10 +7,27 @@ import { Heading } from 'styles/font';
 import { useEffect, useState } from 'react';
 import { getLettersNickname } from 'api/get';
 
-export const LetterHeader = () => {
+//
+//
+//
+
+interface LetterHeaderProps {
+  onMoreButtonClick: () => void;
+}
+
+//
+//
+//
+
+export const LetterHeader = ({ onMoreButtonClick }: LetterHeaderProps) => {
   const navigate = useNavigate();
   const { consultid } = useParams();
+
   const [name, setName] = useState('');
+
+  //
+  //
+  //
   useEffect(() => {
     const fetchNameData = async () => {
       const res: any = await getLettersNickname(consultid);
@@ -25,7 +42,13 @@ export const LetterHeader = () => {
       }
     };
     fetchNameData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  //
+  //
+  //
+
   return (
     <LetterHeaderWrapper>
       <LeftArrow
@@ -34,10 +57,11 @@ export const LetterHeader = () => {
         }}
       />
       <Heading>{name}</Heading>
-      <Option onClick={() => {}} />
+      <Option onClick={onMoreButtonClick} />
     </LetterHeaderWrapper>
   );
 };
+
 const LetterHeaderWrapper = styled.div`
   display: flex;
   align-items: center;
@@ -54,6 +78,8 @@ const LetterHeaderWrapper = styled.div`
 const LeftArrow = styled(LeftArrowIcon)`
   cursor: pointer;
 `;
+
 const Option = styled(OptionIcon)`
   cursor: pointer;
+  padding: 0.4rem 0;
 `;

--- a/src/hooks/useShowComplaintModal.ts
+++ b/src/hooks/useShowComplaintModal.ts
@@ -1,12 +1,12 @@
 import { useRecoilState } from 'recoil';
 import { isComplaintModalOpenState } from 'utils/atom';
 
-export const useShowComplaintModal = () => {
+export const useShowComplainttModal = () => {
   const [isComplaintModalOpen, setIsComplaintModalOpen] = useRecoilState(
     isComplaintModalOpenState,
   );
 
-  const handleMoreButtonClick = () => {
+  const handleComplaintButtonClick = () => {
     setIsComplaintModalOpen(true);
   };
 
@@ -14,5 +14,5 @@ export const useShowComplaintModal = () => {
     setIsComplaintModalOpen(false);
   };
 
-  return { isComplaintModalOpen, handleBackDropClick, handleMoreButtonClick };
+  return { isComplaintModalOpen, handleBackDropClick, handleComplaintButtonClick};
 };

--- a/src/hooks/useShowComplaintModal.ts
+++ b/src/hooks/useShowComplaintModal.ts
@@ -6,7 +6,7 @@ export const useShowComplainttModal = () => {
     isComplaintModalOpenState,
   );
 
-  const handleComplaintButtonClick = () => {
+  const handleMoreButtonClick = () => {
     setIsComplaintModalOpen(true);
   };
 
@@ -14,5 +14,5 @@ export const useShowComplainttModal = () => {
     setIsComplaintModalOpen(false);
   };
 
-  return { isComplaintModalOpen, handleBackDropClick, handleComplaintButtonClick};
+  return { isComplaintModalOpen, handleBackDropClick, handleMoreButtonClick };
 };

--- a/src/hooks/useShowComplaintModal.ts
+++ b/src/hooks/useShowComplaintModal.ts
@@ -1,0 +1,18 @@
+import { useRecoilState } from 'recoil';
+import { isComplaintModalOpenState } from 'utils/atom';
+
+export const useShowComplaintModal = () => {
+  const [isComplaintModalOpen, setIsComplaintModalOpen] = useRecoilState(
+    isComplaintModalOpenState,
+  );
+
+  const handleMoreButtonClick = () => {
+    setIsComplaintModalOpen(true);
+  };
+
+  const handleBackDropClick = () => {
+    setIsComplaintModalOpen(false);
+  };
+
+  return { isComplaintModalOpen, handleBackDropClick, handleMoreButtonClick };
+};

--- a/src/pages/Buyer/BuyerLetter.tsx
+++ b/src/pages/Buyer/BuyerLetter.tsx
@@ -8,6 +8,9 @@ import { ReactComponent as More } from 'assets/icons/icon-more-review-card.svg';
 import { LetterMainSection } from 'components/Buyer/BuyerLetter/LetterMainSection';
 import { LetterTags } from 'components/Buyer/BuyerLetter/LetterTags';
 import { BackIcon, HeaderWrapper } from 'components/Buyer/Common/Header';
+import { BackDrop } from 'components/Common/BackDrop';
+import { ComplaintModal } from 'components/Seller/Common/ComplaintModal';
+import { useShowComplainttModal } from 'hooks/useShowComplaintModal';
 import { useLayoutEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
@@ -45,6 +48,8 @@ export const BuyerLetter = () => {
   const [deadline, setDeadline] = useState<string>('');
   //로딩 state
   const [isLoading, setIsLoading] = useRecoilState<boolean>(isLoadingState);
+  const { isComplaintModalOpen, handleBackDropClick, handleMoreButtonClick } =
+    useShowComplainttModal();
   //상대 이름 state
   const [opponentNickname, setOpponentNickname] = useState<string>('');
 
@@ -172,6 +177,10 @@ export const BuyerLetter = () => {
   //
   //
 
+  const handleComplaintButtonClick = () => {
+    window.open(process.env.REACT_APP_TEMP_CUSTOMER_SERVICE_URL);
+  };
+
   if (isLoading) {
     return (
       <>
@@ -208,8 +217,16 @@ export const BuyerLetter = () => {
           />
           {/* params로 넘어온 id에 해당하는 상담이름 */}
           <Heading color={Grey1}>{opponentNickname}</Heading>
-          <MoreIcon />
+          <MoreIcon onClick={handleMoreButtonClick} />
         </HeaderWrapper>
+        {isComplaintModalOpen && (
+          <>
+            <BackDrop onClick={handleBackDropClick} />
+            <ComplaintModal
+              handleComplaintButtonClick={handleComplaintButtonClick}
+            />
+          </>
+        )}
         <LetterTags
           tagStatus={tagStatus}
           setTagStatus={setTagStatus}

--- a/src/pages/Seller/SellerConsult.tsx
+++ b/src/pages/Seller/SellerConsult.tsx
@@ -14,7 +14,6 @@ export const SellerConsult = () => {
         }}
       />
       <TabA1 isBuyer={false} initState={2} />
-
       <SellerConsultSection />
     </>
   );

--- a/src/pages/Seller/SellerLetter.tsx
+++ b/src/pages/Seller/SellerLetter.tsx
@@ -5,6 +5,7 @@ import {
 } from 'api/get';
 import { BackDrop } from 'components/Common/BackDrop';
 import { BottomButton } from 'components/Seller/Common/BottomButton';
+import { ComplaintModal } from 'components/Seller/Common/ComplaintModal';
 import { LetterBonusQuestionStep } from 'components/Seller/SellerLetter/LetterBonusQuestionStep';
 import { LetterBonusReplyStep } from 'components/Seller/SellerLetter/LetterBonusReplyStep';
 import { LetterComplaintMenu } from 'components/Seller/SellerLetter/LetterComplaintMenu';
@@ -12,6 +13,7 @@ import { LetterHeader } from 'components/Seller/SellerLetter/LetterHeader';
 import { LetterQuestionStep } from 'components/Seller/SellerLetter/LetterQuestionStep';
 import { LetterReplyStep } from 'components/Seller/SellerLetter/LetterReplyStep';
 import { LetterTagListSection } from 'components/Seller/SellerLetter/LetterTagListSection';
+import { useShowComplainttModal } from 'hooks/useShowComplaintModal';
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useRecoilState, useSetRecoilState } from 'recoil';
@@ -21,6 +23,10 @@ import {
   isLoadingState,
   scrollLockState,
 } from 'utils/atom';
+
+//
+//
+//
 
 export const SellerLetter = () => {
   const navigate = useNavigate();
@@ -36,6 +42,17 @@ export const SellerLetter = () => {
     isConsultModalOpenState,
   );
 
+  // 신고 logic
+  const { isComplaintModalOpen, handleBackDropClick, handleMoreButtonClick } =
+    useShowComplainttModal();
+
+  //
+  //
+  //
+  const handleComplaintButtonClick = () => {
+    window.open(process.env.REACT_APP_TEMP_CUSTOMER_SERVICE_URL);
+  };
+
   // 모달 활성화 시 스크롤락
   const setScrollLock = useSetRecoilState(scrollLockState);
   // 각 편지 레벨에 전달할 텍스트, 데드라인, 편지 생성 시각
@@ -50,6 +67,7 @@ export const SellerLetter = () => {
 
   // consultid
   const { consultid } = useParams();
+
   const levelMap = useMemo(() => {
     return {
       질문: 1,
@@ -58,6 +76,7 @@ export const SellerLetter = () => {
       '추가 답장': 4,
     };
   }, []);
+
   // 로딩스피너 여부
   const [isLoading, setIsLoading] = useRecoilState<boolean>(isLoadingState);
   const [isCancel, setIsCancel] = useState<boolean>();
@@ -103,6 +122,7 @@ export const SellerLetter = () => {
     };
 
     fetchLetterInfo();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // 태그 바뀜에 따라 getLetterMessages API 호출
@@ -140,6 +160,7 @@ export const SellerLetter = () => {
       }
     };
     fetchMessages();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tagStatus]);
 
   //
@@ -148,7 +169,7 @@ export const SellerLetter = () => {
 
   return (
     <>
-      <LetterHeader />
+      <LetterHeader onMoreButtonClick={handleMoreButtonClick} />
       <LetterTagListSection
         tagStatus={tagStatus}
         setTagStatus={setTagStatus}
@@ -228,6 +249,14 @@ export const SellerLetter = () => {
               }}
             />
           )}
+        </>
+      )}
+      {isComplaintModalOpen && (
+        <>
+          <BackDrop onClick={handleBackDropClick} />
+          <ComplaintModal
+            handleComplaintButtonClick={handleComplaintButtonClick}
+          />
         </>
       )}
     </>

--- a/src/pages/Seller/SellerLetter.tsx
+++ b/src/pages/Seller/SellerLetter.tsx
@@ -15,7 +15,6 @@ import { LetterTagListSection } from 'components/Seller/SellerLetter/LetterTagLi
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useRecoilState, useSetRecoilState } from 'recoil';
-import styled from 'styled-components';
 import { LoadingSpinner } from 'utils/LoadingSpinner';
 import {
   isConsultModalOpenState,

--- a/src/utils/atom.ts
+++ b/src/utils/atom.ts
@@ -82,6 +82,11 @@ export const isTakingQuizModalOpenState = atom({
   default: false,
 });
 
+export const isComplaintModalOpenState = atom({
+  key: 'isComplaintModalOpenState',
+  default: false,
+});
+
 export const replyState = atom({
   key: 'replyState',
   default: '',


### PR DESCRIPTION
## Checklist

<br>

- [x] 올바른 브랜치에 PR을 보내도록 설정하였나요?
- [x] PR의 라벨을 올바르게 달았나요?

<br>

## Description

<br>
- 더보기 눌렀을 때 신고하기 모달 띄우기 in 편지, 공개상담
<br>

## Related Issues

<br>
#398 
<br>

## To Reveiwer

<br>

- 신고하기 모달, `ComplaintModal` 공통 컴포넌트로 추가했습니다.
- 신고하기 모달을 보여주는 로직을 담당하는 `useShowComplaintModal` 훅 추가했습니다.

앞으로 ComplaintModal에 신고하기 로직인 `handleComplaintButtonClick` 을 props로 전달해주는 방식으로 구현하면 될 거 같습니다

<br>
